### PR TITLE
fix: use importResolve to get framework path

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,11 +31,11 @@
   "dependencies": {},
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.17.2",
+    "@eggjs/bin": "^7.0.0",
     "@eggjs/tsconfig": "1",
     "@types/mocha": "10",
     "@types/node": "22",
     "coffee": "5",
-    "egg-bin": "^6.13.0",
     "eslint": "8",
     "eslint-config-egg": "14",
     "mm": "4",

--- a/src/framework.ts
+++ b/src/framework.ts
@@ -1,7 +1,11 @@
+import { debuglog } from 'node:util';
 import path from 'node:path';
 import assert from 'node:assert';
 import { existsSync } from 'node:fs';
 import { readJSONSync } from './utils.js';
+import { importResolve } from './import.js';
+
+const debug = debuglog('@eggjs/utils/framework');
 
 const initCwd = process.cwd();
 
@@ -66,18 +70,19 @@ function assertAndReturn(frameworkName: string, moduleDir: string) {
     // if frameworkName is scoped package, like @ali/egg
     if (frameworkName.startsWith('@') && frameworkName.includes('/')) {
       globalModuleDir = path.join(
-        require.resolve(`${frameworkName}/package.json`),
+        importResolve(`${frameworkName}/package.json`),
         '../../..',
       );
     } else {
       globalModuleDir = path.join(
-        require.resolve(`${frameworkName}/package.json`),
+        importResolve(`${frameworkName}/package.json`),
         '../..',
       );
     }
     moduleDirs.add(globalModuleDir);
   } catch (err) {
     // ignore
+    debug('importResolve %s on %s error: %s', frameworkName, moduleDir, err);
   }
   for (const moduleDir of moduleDirs) {
     const frameworkPath = path.join(moduleDir, frameworkName);

--- a/src/import.ts
+++ b/src/import.ts
@@ -188,7 +188,9 @@ export function importResolve(filepath: string, options?: ImportResolveOptions) 
         // resolve will return file:// URL on Linux and MacOS expect on Windows
         moduleFilePath = fileURLToPath(moduleFilePath);
       }
-      if (!fs.existsSync(moduleFilePath)) {
+      debug('[importResolve] import.meta.resolve %o => %o', filepath, moduleFilePath);
+      const stat = fs.statSync(moduleFilePath, { throwIfNoEntry: false });
+      if (!stat?.isFile()) {
         throw new TypeError(`Cannot find module ${filepath}, because ${moduleFilePath} does not exists`);
       }
     } else {

--- a/test/fixtures/cjs-index/index.cjs
+++ b/test/fixtures/cjs-index/index.cjs
@@ -1,0 +1,5 @@
+module.exports = {
+  foo: 'bar',
+};
+
+module.exports.one = 1;

--- a/test/fixtures/cjs-index/package.json
+++ b/test/fixtures/cjs-index/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "commonjs"
+}

--- a/test/fixtures/cjs/run.js
+++ b/test/fixtures/cjs/run.js
@@ -1,0 +1,5 @@
+const { importResolve } = require('../../../');
+
+console.log('%o', importResolve(__dirname, {
+  paths: __dirname,
+}));

--- a/test/fixtures/egg-app/config/plugin.test.js
+++ b/test/fixtures/egg-app/config/plugin.test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const path = require('path');
 
 exports.p = {

--- a/test/fixtures/egg-app/get_loadunit.js
+++ b/test/fixtures/egg-app/get_loadunit.js
@@ -4,6 +4,7 @@ const { getLoadUnits } = require('../../..');
   console.log(process.argv[2]);
   const units = await getLoadUnits(JSON.parse(process.argv[2]));
   console.log('get %s plugin', units.filter(p => p.type === 'plugin').length);
+  // console.log(units.filter(p => p.type === 'plugin'));
   console.log('get %s framework', units.filter(p => p.type === 'framework').length);
   console.log('get %s app', units.filter(p => p.type === 'app').length);
 })();

--- a/test/fixtures/egg-app/package.json
+++ b/test/fixtures/egg-app/package.json
@@ -2,7 +2,7 @@
   "name": "egg-app",
   "dependencies": {
     "egg": "beta",
-    "@eggjs/core": "6",
+    "@eggjs/core": "beta",
     "framework-demo": "^1.0.1"
   }
 }

--- a/test/fixtures/esm-index/index.mjs
+++ b/test/fixtures/esm-index/index.mjs
@@ -1,0 +1,5 @@
+export default {
+  foo: 'bar',
+};
+
+export const one = 1;

--- a/test/fixtures/esm-index/package.json
+++ b/test/fixtures/esm-index/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/test/import.test.ts
+++ b/test/import.test.ts
@@ -1,4 +1,5 @@
 import { strict as assert } from 'node:assert';
+import coffee from 'coffee';
 import { importResolve, importModule } from '../src/index.js';
 import { getFilepath } from './helper.js';
 
@@ -7,10 +8,19 @@ describe('test/import.test.ts', () => {
     it('should work on cjs', () => {
       assert.equal(importResolve(getFilepath('cjs')), getFilepath('cjs/index.js'));
       assert.equal(importResolve(getFilepath('cjs/exports')), getFilepath('cjs/exports.js'));
+      assert.equal(importResolve(getFilepath('cjs-index')), getFilepath('cjs-index/index.cjs'));
+    });
+
+    it('should work on commonjs and require exists', () => {
+      return coffee.fork(getFilepath('cjs/run.js'))
+        // .debug()
+        .expect('stdout', /index\.js/)
+        .end();
     });
 
     it('should work on esm', () => {
       assert.equal(importResolve(getFilepath('esm')), getFilepath('esm/index.js'));
+      assert.equal(importResolve(getFilepath('esm-index')), getFilepath('esm-index/index.mjs'));
       assert.equal(importResolve(getFilepath('esm/config/plugin')), getFilepath('esm/config/plugin.js'));
       assert.throws(() => {
         importResolve(getFilepath('esm/config/plugin.default'));


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced new module exports for both CommonJS and ESM formats, enhancing export capabilities.
	- Added debugging capabilities for improved error handling in module resolution.

- **Bug Fixes**
	- Enhanced error handling in the `importResolve` function to provide more context during module resolution failures.

- **Documentation**
	- Updated test suite to improve coverage for module resolution tests.

- **Chores**
	- Updated dependency versions in `package.json` files for various modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->