### PR TITLE
fix: try to use index.* when package.json not exists

### DIFF
--- a/src/import.ts
+++ b/src/import.ts
@@ -142,11 +142,12 @@ function tryToResolveByDirnameFromPackage(dirname: string, pkg: any): string | u
 }
 
 function tryToResolveByDirname(dirname: string): string | undefined {
+  let pkg: any = {};
   const pkgFile = path.join(dirname, 'package.json');
   if (fs.existsSync(pkgFile)) {
-    const pkg = JSON.parse(fs.readFileSync(pkgFile, 'utf-8'));
-    return tryToResolveByDirnameFromPackage(dirname, pkg);
+    pkg = JSON.parse(fs.readFileSync(pkgFile, 'utf-8'));
   }
+  return tryToResolveByDirnameFromPackage(dirname, pkg);
 }
 
 export function importResolve(filepath: string, options?: ImportResolveOptions) {

--- a/test/fixtures/cjs/extend/index.js
+++ b/test/fixtures/cjs/extend/index.js
@@ -1,0 +1,1 @@
+exports.extend = true;

--- a/test/fixtures/ts-module/extend/index.ts
+++ b/test/fixtures/ts-module/extend/index.ts
@@ -1,0 +1,1 @@
+export const extend = true;

--- a/test/import.test.ts
+++ b/test/import.test.ts
@@ -9,6 +9,7 @@ describe('test/import.test.ts', () => {
       assert.equal(importResolve(getFilepath('cjs')), getFilepath('cjs/index.js'));
       assert.equal(importResolve(getFilepath('cjs/exports')), getFilepath('cjs/exports.js'));
       assert.equal(importResolve(getFilepath('cjs-index')), getFilepath('cjs-index/index.cjs'));
+      assert.equal(importResolve(getFilepath('cjs/extend')), getFilepath('cjs/extend/index.js'));
     });
 
     it('should work on commonjs and require exists', () => {
@@ -29,6 +30,7 @@ describe('test/import.test.ts', () => {
 
     it('should work on ts-module', () => {
       assert.equal(importResolve(getFilepath('ts-module')), getFilepath('ts-module/index.ts'));
+      assert.equal(importResolve(getFilepath('ts-module/extend')), getFilepath('ts-module/extend/index.ts'));
     });
 
     it('should work on typescript without dist', () => {
@@ -51,6 +53,16 @@ describe('test/import.test.ts', () => {
   });
 
   describe('importModule()', () => {
+    it('should import extend/index.js from extend on cjs', async () => {
+      const obj = await importModule(getFilepath('cjs/extend'));
+      assert.equal(obj.extend, true);
+    });
+
+    it('should import extend/index.js from extend on ts', async () => {
+      const obj = await importModule(getFilepath('ts-module/extend'), { importDefaultOnly: true });
+      assert.equal(obj.extend, true);
+    });
+
     it('should work on cjs', async () => {
       let obj = await importModule(getFilepath('cjs'));
       if (process.version.startsWith('v23.')) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new export `extend` in both CommonJS and TypeScript modules, allowing access to a boolean value of `true`.

- **Bug Fixes**
	- Improved handling of the `pkg` variable in the module resolution process.

- **Tests**
	- Added new test cases for verifying module resolution and imports for the `extend` modules in CommonJS and TypeScript contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->