### PR TITLE
fix: import resolve find in paths's node_modules

### DIFF
--- a/src/import.ts
+++ b/src/import.ts
@@ -202,6 +202,17 @@ export function importResolve(filepath: string, options?: ImportResolveOptions) 
     }
   }
 
+  // find from node_modules
+  for (const p of paths) {
+    const resolvedPath = path.join(p, 'node_modules', filepath);
+    moduleFilePath = tryToResolveFromAbsoluteFile(resolvedPath);
+    if (moduleFilePath) {
+      debug('[importResolve:node_modules] %o => %o => %o',
+        filepath, resolvedPath, moduleFilePath);
+      return moduleFilePath;
+    }
+  }
+
   const extname = path.extname(filepath);
   if ((!isAbsolute && extname === '.json') || !isESM) {
     moduleFilePath = getRequire().resolve(filepath, {

--- a/test/fixtures/cjs/node_modules/inject/index.js
+++ b/test/fixtures/cjs/node_modules/inject/index.js
@@ -1,0 +1,1 @@
+exports.foo = 'bar';

--- a/test/fixtures/cjs/node_modules/inject/package.json
+++ b/test/fixtures/cjs/node_modules/inject/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "inject"
+}

--- a/test/fixtures/esm/node_modules/inject/index.js
+++ b/test/fixtures/esm/node_modules/inject/index.js
@@ -1,0 +1,1 @@
+export const foo = 'bar';

--- a/test/fixtures/esm/node_modules/inject/package.json
+++ b/test/fixtures/esm/node_modules/inject/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "inject"
+}

--- a/test/import.test.ts
+++ b/test/import.test.ts
@@ -27,6 +27,12 @@ describe('test/import.test.ts', () => {
       }), getFilepath('cjs/index.js'));
     });
 
+    it('should inject commonjs package from {paths}/node_modules', () => {
+      assert.equal(importResolve('inject', {
+        paths: [ getFilepath('cjs') ],
+      }), getFilepath('cjs/node_modules/inject/index.js'));
+    });
+
     it('should work on commonjs and require exists', () => {
       return coffee.fork(getFilepath('cjs/run.js'))
         // .debug()
@@ -47,6 +53,12 @@ describe('test/import.test.ts', () => {
       assert.throws(() => {
         importResolve(getFilepath('esm/config/plugin.default'));
       }, /Cannot find module/);
+    });
+
+    it('should inject esm package from {paths}/node_modules', () => {
+      assert.equal(importResolve('inject', {
+        paths: [ getFilepath('esm') ],
+      }), getFilepath('esm/node_modules/inject/index.js'));
     });
 
     it('should work on ts-module', () => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced module resolution to search for modules within the `node_modules` directory
	- Added support for resolving both CommonJS and ECMAScript (ESM) packages

- **Tests**
	- Expanded test coverage for package resolution in different module systems

<!-- end of auto-generated comment: release notes by coderabbit.ai -->