### PR TITLE
fix: support resolve from scoped package parent node_modules

### DIFF
--- a/src/error/ImportResolveError.ts
+++ b/src/error/ImportResolveError.ts
@@ -1,0 +1,13 @@
+export class ImportResolveError extends Error {
+  filepath: string;
+  paths: string[];
+
+  constructor(filepath: string, paths: string[], error: Error) {
+    const message = `${error.message}, paths: ${JSON.stringify(paths)}`;
+    super(message, { cause: error });
+    this.name = this.constructor.name;
+    this.filepath = filepath;
+    this.paths = paths;
+    Error.captureStackTrace(this, this.constructor);
+  }
+}

--- a/src/error/index.ts
+++ b/src/error/index.ts
@@ -1,0 +1,1 @@
+export * from './ImportResolveError.js';

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ export { getFrameworkPath } from './framework.js';
 export { getPlugins, getConfig, getLoadUnits } from './plugin.js';
 export { getFrameworkOrEggPath } from './deprecated.js';
 export * from './import.js';
+export * from './error/index.js';
 
 // support import utils from '@eggjs/utils'
 export default {

--- a/test/fixtures/cjs/node_modules/@foo/bar/index.js
+++ b/test/fixtures/cjs/node_modules/@foo/bar/index.js
@@ -1,0 +1,1 @@
+exports.foo = 'bar';


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new `ImportResolveError` class for more detailed import resolution error handling
	- Enhanced module resolution process to check parent `node_modules` directories

- **Bug Fixes**
	- Improved error reporting for import resolution failures

- **Tests**
	- Added test cases for `ImportResolveError` and expanded module resolution testing

- **Documentation**
	- Improved error messaging for import-related issues

<!-- end of auto-generated comment: release notes by coderabbit.ai -->