### PR TITLE
fix: export isSupportTypeScript

### DIFF
--- a/src/import.ts
+++ b/src/import.ts
@@ -16,7 +16,7 @@ export interface ImportModuleOptions extends ImportResolveOptions {
   importDefaultOnly?: boolean;
 }
 
-const isESM = typeof require === 'undefined';
+export const isESM = typeof require === 'undefined';
 const nodeMajorVersion = parseInt(process.versions.node.split('.', 1)[0], 10);
 const supportImportMetaResolve = nodeMajorVersion >= 18;
 
@@ -33,7 +33,7 @@ function getRequire() {
 }
 
 let _supportTypeScript: boolean | undefined;
-function isSupportTypeScript() {
+export function isSupportTypeScript() {
   if (_supportTypeScript === undefined) {
     const extensions = getRequire().extensions;
     _supportTypeScript = extensions['.ts'] !== undefined;

--- a/test/fixtures/egg-app/package.json
+++ b/test/fixtures/egg-app/package.json
@@ -2,7 +2,7 @@
   "name": "egg-app",
   "dependencies": {
     "egg": "beta",
-    "@eggjs/core": "beta",
+    "@eggjs/core": "6",
     "framework-demo": "^1.0.1"
   }
 }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,5 +1,6 @@
 import { strict as assert } from 'node:assert';
 import { detectType, EggType } from '../src/index.js';
+import * as all from '../src/index.js';
 import { getFilepath } from './helper.js';
 
 describe('test/index.test.ts', () => {
@@ -26,6 +27,26 @@ describe('test/index.test.ts', () => {
       const baseDir = getFilepath('no-package-json');
       assert.equal(await detectType(baseDir), EggType.unknown);
       assert.equal(await detectType(baseDir), 'unknown');
+    });
+  });
+
+  describe('export all', () => {
+    it('should keep checking', () => {
+      assert.deepEqual(Object.keys(all), [
+        'EggType',
+        'ImportResolveError',
+        'default',
+        'detectType',
+        'getConfig',
+        'getFrameworkOrEggPath',
+        'getFrameworkPath',
+        'getLoadUnits',
+        'getPlugins',
+        'importModule',
+        'importResolve',
+        'isESM',
+        'isSupportTypeScript',
+      ]);
     });
   });
 });

--- a/test/plugin.test.ts
+++ b/test/plugin.test.ts
@@ -210,7 +210,7 @@ describe('test/plugin.test.ts', () => {
       });
       await coffee.fork(bin, [ args ], { cwd: tmp })
         .debug()
-        .expect('stdout', /get app configs \["session"/)
+        .expect('stdout', /get app configs \["middleware","coreMiddleware","session"/)
         .expect('code', 0)
         .end();
       const config = await utils.getConfig({

--- a/test/plugin.test.ts
+++ b/test/plugin.test.ts
@@ -180,7 +180,7 @@ describe('test/plugin.test.ts', () => {
       });
       await coffee.fork(bin, [ args ], { cwd: tmp })
         .debug()
-        .expect('stdout', /get app configs \["session"/)
+        .expect('stdout', /get app configs \["middleware","coreMiddleware","session"/)
         .expect('code', 0)
         .end();
     });
@@ -195,7 +195,7 @@ describe('test/plugin.test.ts', () => {
       });
       await coffee.fork(bin, [ args ], { cwd: tmp })
         .debug()
-        .expect('stdout', /get app configs \["session"/)
+        .expect('stdout', /get app configs \["middleware","coreMiddleware","session"/)
         .expect('code', 0)
         .end();
     });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Exported `isESM` constant and `isSupportTypeScript` function to improve module accessibility.
- **Tests**
	- Added comprehensive export verification test to ensure all expected entities are correctly exported.
	- Updated assertions in `getConfig()` tests to reflect enhanced expected output for application configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->